### PR TITLE
Redesign Bnr voor sprint review

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -334,6 +334,8 @@ nav li a {
 
 
 .gridcontainter {
+    display: grid;
+    row-gap: 3em;
 
     padding: 1rem 1rem 1rem 2em;
 }
@@ -566,7 +568,7 @@ label {
     margin-bottom: 1em;
     /*margin: 0 auto;*/
 }
-.divniews {
+.divnieuws {
     display: grid;
     grid-template-columns: 1fr;
     row-gap: 5em;
@@ -795,13 +797,6 @@ label {
     /*    place-items: center;*/
     /*}*/
 
-    .divniews{
-        grid-column-start: 1;
-        grid-column-end: 3;
-        margin: 0 auto;
-
-        grid-row:2;
-    }
 
     .imageBNR {
         width: 379px;
@@ -830,6 +825,14 @@ label {
 
     }
 
+    .iconsDesktopNav {
+        position: relative;
+        left: 0;
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        column-gap: 1em;
+    }
+
 
 }
 
@@ -840,13 +843,7 @@ label {
         column-gap: 1em;
     }
 
-    .iconsDesktopNav {
-        position: relative;
-        left: 0;
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        column-gap: 1em;
-    }
+
 
     nav li a {
         display: grid;
@@ -869,14 +866,11 @@ label {
         /*column-gap: 2em;*/
         display: grid;
         justify-content: center;
-        /*margin: 0 auto;*/
+        grid-template-columns: 1fr ;
+        margin: 1em 1em 1em 1em ;
+        gap: 6em;
     }
-    .divniews{
-        grid-column-start: 1;
-        grid-column-end: 3;
-        display: grid;
-        grid-template-columns: auto auto;
-    }
+
     /*.gridcontainter{*/
     /*    grid-template-columns: 692px 411px;*/
     /*}*/

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -52,6 +52,13 @@ li {
     list-style: none;
 
 }
+a {
+    color: var(--color-black);
+    text-decoration: none;
+}
+a:hover{
+    text-decoration: underline;
+}
 
 /*hier begint  de navigatie*/
 
@@ -649,6 +656,7 @@ label {
     justify-content: space-between;
     align-items: center;
     margin: 0.25rem;
+    border: 1px solid var(--gray-border);
 
 }
 
@@ -668,11 +676,22 @@ label {
 }
 
 .nieuws__link {
+    /*color: var(--color-black);*/
+    /*text-decoration: none;*/
+    /*padding: 0.4em;*/
+    /*border: solid var(--color-black) 3px;*/
+    /*background-color: white;*/
+    background-color: var(--white);
     color: var(--color-black);
+    border: 1px solid var(--gray-border);
     text-decoration: none;
-    padding: 0.4em;
-    border: solid var(--color-black) 3px;
-    background-color: white;
+    padding: .5rem .75rem;
+    font-weight: 700;
+    transition: background-color .2s ease-in-out;
+    outline-offset: 0;
+    font-size: 17px;
+
+
 }
 
 .nieuws__link:hover {
@@ -682,7 +701,7 @@ label {
 
 .sectionArticles {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 2em));
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 2em;
 
 }
@@ -731,10 +750,14 @@ label {
 .article__img {
     width: 100%;
     height: auto;
-    object-fit: contain;
+    object-fit: cover;
 }
 .stylingButton{
     text-align: center;
+    display: grid;
+    width: 11em;
+    margin: 0 auto;
+
     /*margin-top: 2em;*/
 }
 .bekijkmeerButton{

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -43,19 +43,13 @@ body {
 
 }
 
-svg {
-    font-size: 1.2em;
-    background-color: var(--color-black);
-}
+/*svg {*/
+/*    font-size: 1.2em;*/
+/*    background-color: var(--color-black);*/
+/*}*/
 
 li {
     list-style: none;
-
-}
-
-H1 {
-    position: relative;
-    z-index: 1;
 
 }
 
@@ -72,9 +66,9 @@ H1 {
 
 .nav {
     display: flex;
-/ justify-content: space-between;
+ justify-content: space-between;
     align-items: center;
-/
+
 }
 
 .nav ul {
@@ -336,22 +330,36 @@ nav li a {
 /*hier eindigt de navigaite*/
 
 /*hier negint de main*/
+
+
+
 .gridcontainter {
     display: grid;
-    grid-template-columns: 1fr;
+    /*grid-template-columns: 1fr;*/
     row-gap: 2em;
     padding: 1rem;
 }
 
-.intro {
-    padding: 1rem;
-    /*margin: 0 auto;*/
-
+#top, .nieuws__h1, #nieuws {
+    font-size: 2.3rem;
+    margin-bottom: 0.5em;
     line-height: 1.5em;
 }
-.intoP {
-    border-bottom: .5px solid var(--gray-border);
+
+.intro {
+    padding: 1rem;
+    margin: 0 auto;
+
+    grid-column: 1;
+    line-height: 1.5em;
 }
+.intro p {
+    font-size: 1.4rem;
+    margin-bottom: 1em;
+    line-height: 1.5em;
+
+}
+
 
 .imageBNR {
     width: 60%;
@@ -361,14 +369,16 @@ nav li a {
     display: grid;
 }
 
-.imageBNR {
-    width: 50%;
-    height: auto;
-    object-fit: cover;
-    margin-top: 2em;
-    display: grid;
-}
 
+.stylingplaylist{
+    display: grid;
+    grid-template-columns: 1fr;
+    row-gap: 2em;
+    padding: 1rem;
+    grid-column: 1;
+    margin: 0 auto;
+
+}
 .playlist {
     /*margin: 0 auto;*/
     /* display: grid; */
@@ -377,7 +387,7 @@ nav li a {
     grid-template-rows: auto auto;
     display: grid;
     column-gap: 0.5em;
-    border-bottom: .5px solid var(--gray-border);
+    /*border-bottom: .5px solid var(--gray-border);*/
 
 
     flex-direction: row;
@@ -412,6 +422,8 @@ label {
     position: absolute;
     top: 3em;
     left: 0em;
+    border: none;
+    background-color: transparent;
 }
 
 
@@ -539,30 +551,38 @@ label {
 /*einde van de plyalist*/
 
 /*dit is het blok met het nieuws*/
+
+#nieuws{
+    font-size: 1.75rem;
+    margin-bottom: 1em;
+    /*margin: 0 auto;*/
+}
 .divniews {
     display: grid;
     grid-template-columns: 1fr;
     row-gap: 5em;
     padding: 1rem;
 
-    margin: 0 auto;
+    /*margin: 0 auto;*/
 }
 
 .nieuws {
-    /*background-color: var(--yellow);*/
+    background-color: var(--yellow);
+    /*todo toeveogen dat diagnaal */
     position: relative;
     overflow: hidden;
     transition: color .5s linear;
-    background-color: var(--yellow) 50%, var(--white) 50%;
+    /*background-color: var(--yellow) 50%, var(--white) 50%;*/
     background-size: 100% 100%; /* Ensures colors fill the entire section */
     background-position: 0 0;
+
 
 }
 
 .nieuws__h1 {
     padding-left: 0.5em;
     padding-top: 0.5em;
-    font-size: 20px;
+    font-size: 1.75rem;
     font-weight: 700;
     color: var(--color-black);
     line-height: 1.2;
@@ -570,34 +590,34 @@ label {
     /*justify-content: center;*/
 }
 
-.nieuws__yellowBackground {
+/*.nieuws__yellowBackground {*/
+
+/*    background-image: linear-gradient( 50% ,var(--yellow), white);*/
+/*    !*background-color: var(--yellow);*!*/
+
+/*    overflow: hidden;*/
+/*    z-index: -1;*/
+/*    position: absolute;*/
+/*    left: 0;*/
+/*    top: 0;*/
+/*    !*width: 42%;*!*/
+/*    height: 100%;*/
+/*    transition: background-color .5s linear;*/
 
 
-    background-color: var(--yellow);
+/*}*/
 
-    overflow: hidden;
-    z-index: -1;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 384px;
-    height: 100%;
-    transition: background-color .5s linear;
-
-
-}
-
-.nieuws__yellowBackground:after {
-    content: "";
-    position: absolute;
-    top: 42px;
-    right: 0;
-    left: 283px;
-    background: var(--white);
-    width: 202px;
-    height: 202px;
-    transform: rotate(45deg);
-}
+/*.nieuws__yellowBackground:after {*/
+/*    content: "";*/
+/*    position: absolute;*/
+/*    top: 42px;*/
+/*    right: 0;*/
+/*    left: 177px;*/
+/*    background: var(--white);*/
+/*    width: 202px;*/
+/*    height: 202px;*/
+/*    transform: rotate(45deg);*/
+/*}*/
 
 
 .nieuws__carousssel {
@@ -618,7 +638,7 @@ label {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 1rem;
+    margin: 0.25rem;
 
 }
 
@@ -663,10 +683,10 @@ label {
     column-gap: 1em;
 
     row-gap: .5rem;
-    border-top: .5px solid var(--gray-border);
+    border: .5px solid var(--gray-border);
     height: 100%;
     transition: background-color .2s ease-in-out;
-    padding-top: 2em;
+   padding: 2em;
 
 }
 
@@ -698,12 +718,25 @@ label {
 
 
 .article__img {
-    width: 100%;
+    width: 80%;
     height: auto;
     object-fit: contain;
 }
+.stylingButton{
+    text-align: center;
+}
+.bekijkmeerButton{
+    display: inline-block;
+    outline-offset: 0;
+    color: var(--white);
+    font-weight: 700;
+    background-color: var(--color-black);
+    transition: background-color .2s ease-in-out;
+    /*padding: 0.25rem 0.25rem 0.75rem 0.75rem;*/
+ padding: 1rem;
+}
 
-@container (min-width: 500px) {
+@container (min-width: 300px) {
     .playlist__div {
         rotate: 0deg;
         position: static;
@@ -716,9 +749,45 @@ label {
 }
 
 @media (min-width: 768px) {
+    .gridcontainter{
+        grid-template-columns: 1fr 1fr;
+        /*column-gap: 2em;*/
+        justify-content: center;
+        margin: 0 auto;
+    }
+    #top,.nieuws__h1,#nieuws{
+        font-size: 2.5rem;
+    }
+
+    .intro p {
+        font-size: 1.5rem;
+    }
+    .intro{
+        grid-column: 1;
+        margin-top: 10em;
+        height: 10em;
+        margin-left: 2em;
+    }
+    .stylingplaylist{
+        grid-column: 2;
+        border: #d7d2cb;
+
+    }
+    /*.intro,.stylingplaylist{*/
+    /*    !*grid-column-start: 2;*!*/
+    /*    margin: 0 auto;*/
+    /*    justify-self: center;*/
+    /*    place-items: center;*/
+    /*}*/
+
+    .divniews{
+        grid-column-start: 1;
+        grid-column-end: 3;
+        margin: 0 auto;
+    }
 
     .imageBNR {
-        width: 300px;
+        width: 379px;
         height: auto;
         object-fit: cover;
         margin-top: 2em;

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -386,6 +386,7 @@ nav li a {
     padding: 1rem;
     grid-column: 1;
     margin: 0 auto;
+    box-shadow: 0 0 300px 0 rgba(0,0,0,0.1);
 
 }
 .playlist {
@@ -784,7 +785,7 @@ label {
     }
     .stylingplaylist{
         grid-column: 2;
-        border: #d7d2cb;
+        /*box-shadow: 0 0 300px 0 rgba(0,0,0,0.1);*/
 
     }
     /*.intro,.stylingplaylist{*/

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -334,13 +334,21 @@ nav li a {
 
 
 .gridcontainter {
-    display: grid;
-    /*grid-template-columns: 1fr;*/
-    row-gap: 2em;
-    padding: 1rem;
+
+    padding: 1rem 1rem 1rem 2em;
 }
 
-#top, .nieuws__h1, #nieuws {
+#top {
+    font-size: 2.3rem;
+    margin-bottom: 0.5em;
+    line-height: 1.5em;
+}
+.nieuws__h1{
+    font-size: 2.3rem;
+    margin-bottom: 0.5em;
+    line-height: 1.5em;
+}
+#nieuws{
     font-size: 2.3rem;
     margin-bottom: 0.5em;
     line-height: 1.5em;
@@ -353,12 +361,13 @@ nav li a {
     grid-column: 1;
     line-height: 1.5em;
 }
-.intro p {
+.intro ul p {
     font-size: 1.4rem;
     margin-bottom: 1em;
     line-height: 1.5em;
 
 }
+
 
 
 .imageBNR {
@@ -553,7 +562,6 @@ label {
 /*dit is het blok met het nieuws*/
 
 #nieuws{
-    font-size: 1.75rem;
     margin-bottom: 1em;
     /*margin: 0 auto;*/
 }
@@ -582,7 +590,6 @@ label {
 .nieuws__h1 {
     padding-left: 0.5em;
     padding-top: 0.5em;
-    font-size: 1.75rem;
     font-weight: 700;
     color: var(--color-black);
     line-height: 1.2;
@@ -724,6 +731,7 @@ label {
 }
 .stylingButton{
     text-align: center;
+    margin-top: 2em;
 }
 .bekijkmeerButton{
     display: inline-block;
@@ -748,25 +756,31 @@ label {
     }
 }
 
-@media (min-width: 768px) {
-    .gridcontainter{
-        grid-template-columns: 1fr 1fr;
-        /*column-gap: 2em;*/
-        justify-content: center;
-        margin: 0 auto;
+@media (min-width: 900px) {
+
+    .playlist-intro{
+        display: grid;
+        grid-template-columns: 1fr 30em;
+        column-gap: 1em;
+        max-width: 74em;
     }
     #top,.nieuws__h1,#nieuws{
         font-size: 2.5rem;
     }
 
+    .intro ul {
+        font-size: 1.5rem;
+    }
     .intro p {
         font-size: 1.5rem;
+    }
+    ul{
+        list-style-type: disc;
     }
     .intro{
         grid-column: 1;
         margin-top: 10em;
         height: 10em;
-        margin-left: 2em;
     }
     .stylingplaylist{
         grid-column: 2;
@@ -784,6 +798,8 @@ label {
         grid-column-start: 1;
         grid-column-end: 3;
         margin: 0 auto;
+
+        grid-row:2;
     }
 
     .imageBNR {
@@ -848,6 +864,21 @@ label {
     #menuToggle {
         display: none;
     }
+    .gridcontainter{
+        /*column-gap: 2em;*/
+        display: grid;
+        justify-content: center;
+        /*margin: 0 auto;*/
+    }
+    .divniews{
+        grid-column-start: 1;
+        grid-column-end: 3;
+        display: grid;
+        grid-template-columns: auto auto;
+    }
+    /*.gridcontainter{*/
+    /*    grid-template-columns: 692px 411px;*/
+    /*}*/
 
 }
 

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -336,8 +336,8 @@ nav li a {
 .gridcontainter {
     display: grid;
     row-gap: 3em;
-
-    padding: 1rem 1rem 1rem 2em;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
 }
 
 #top {
@@ -350,10 +350,11 @@ nav li a {
     margin-bottom: 0.5em;
     line-height: 1.5em;
 }
+
 #nieuws{
     font-size: 2.3rem;
     margin-bottom: 0.5em;
-    line-height: 1.5em;
+    line-height: 1.5;
 }
 
 .intro {
@@ -373,7 +374,7 @@ nav li a {
 
 
 .imageBNR {
-    width: 60%;
+    width: 100%;
     height: auto;
     object-fit: cover;
     /*margin: 0 auto;*/
@@ -571,8 +572,7 @@ label {
 .divnieuws {
     display: grid;
     grid-template-columns: 1fr;
-    row-gap: 5em;
-    padding: 1rem;
+    row-gap: 2em;
 
     /*margin: 0 auto;*/
 }
@@ -682,21 +682,22 @@ label {
 
 .sectionArticles {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 2em));
     gap: 2em;
 
 }
 
+
 .articles {
     display: grid;
-    grid-template-columns: 1fr;
+    /*grid-template-columns: 1fr;*/
     column-gap: 1em;
 
     row-gap: .5rem;
     border: .5px solid var(--gray-border);
     height: 100%;
     transition: background-color .2s ease-in-out;
-   padding: 2em;
+   padding: 1em;
 
 }
 
@@ -728,13 +729,13 @@ label {
 
 
 .article__img {
-    width: 80%;
+    width: 100%;
     height: auto;
     object-fit: contain;
 }
 .stylingButton{
     text-align: center;
-    margin-top: 2em;
+    /*margin-top: 2em;*/
 }
 .bekijkmeerButton{
     display: inline-block;
@@ -745,6 +746,7 @@ label {
     transition: background-color .2s ease-in-out;
     /*padding: 0.25rem 0.25rem 0.75rem 0.75rem;*/
  padding: 1rem;
+    font-size: 18px;
 }
 
 @container (min-width: 300px) {
@@ -758,7 +760,39 @@ label {
 
     }
 }
+@media (min-width: 400px) {
+    .gridcontainter{
+        padding: 2em;
+    }
 
+}
+@media (min-width: 570px) {
+    .imageBNR{
+        width: 504px;
+        height: auto;
+
+    }
+    .stylingplaylist{
+        max-width: 770px;
+        height:auto;
+    }
+    .sectionArticles{
+        grid-template-columns: repeat(auto-fit, minmax(390px, 1fr));
+    }
+    .article__img{
+        /*width: 70%;*/
+        height: auto;
+
+    }
+    /*.sectionArticles{*/
+    /*    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));*/
+    /*}*/
+}
+@media (min-width: 770px) {
+
+
+
+}
 @media (min-width: 900px) {
 
     .playlist-intro{
@@ -816,14 +850,7 @@ label {
         padding: 24px;
     }
 
-    .sectionArticles {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(390px, 0));
 
-
-        gap: 2em;
-
-    }
 
     .iconsDesktopNav {
         position: relative;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,8 +10,10 @@
         <section class="intro">
             <h1 id="top">BNR business beats </h1>
 
-            <p>Hier kunt u naar muziek luisteeren met ieder half uur een niewsbulleting. Verder kunt u ook het laatste niews lezen
-            ga naar: <a href="#nieuws">Nieuws</a>
+            <p>
+                Blijf op de hoogte van het laatste nieuws terwijl je geniet van jouw favoriete muziek. Elk half uur een nieuwsbulletin, en tussendoor non-stop muziek.
+            <br>
+                ga naar: <a href="#nieuws">Nieuws</a>
 
             </p>
 
@@ -123,9 +125,9 @@
         </section>
 
 
-        <section class="">
-            <h1 id="nieuws">zie alle nieuwsartikelen</h1>
-            <div class="sectionArticles">
+        <section class="sectionArticles" id="nieuws">
+<!--            <h1 id="nieuws">zie alle nieuwsartikelen</h1>-->
+
 
                 <% firstTenArticles.forEach(article => { %>
                     <article class="articles">
@@ -148,7 +150,6 @@
                         <% } %>
                     </article>
                 <% }) %>
-            </div>
             <div class="stylingButton">
                 <a
                     class="bekijkmeerButton"

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -150,13 +150,14 @@
                         <% } %>
                     </article>
                 <% }) %>
-            <div class="stylingButton">
-                <a
+
+        </section>
+        <div class="stylingButton">
+            <a
                     class="bekijkmeerButton"
                     href="">Alles bekijken
-                </a>
-            </div>
-        </section>
+            </a>
+        </div>
     </div>
 
 </main>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,41 +6,47 @@
 <main class="gridcontainter">
 
     <!--    hier nth child gebruiken-->
-    <section class="intro">
-        <h1 id="top">BNR business beats </h1>
-        <p>Luister naar muziek en krijg ieder half uur een niewsbericht  Ook kunt u de laatste niews artikelen lezen</p>
+    <div class="playlist-intro">
+        <section class="intro">
+            <h1 id="top">BNR business beats </h1>
+            <p>Hier kunt u:</p>
+            <ul>
+                <li>luister naar muziek</li>
+                <li>     <a href="#nieuws">Nieuwsberichten lezen</a></li>
+            </ul>
+            <p>Hier kunt u naar muziek luisteeren met ieder half uur een niewsbulleting. Verder kunt u ook het laatste niews lezen</p>
 
-        <!--        https://developer.mozilla.org/en-US/docs/Web/CSS/animation-->
-        <!--        todo kijken of image in div kan playlist kan-->
+            <!--        https://developer.mozilla.org/en-US/docs/Web/CSS/animation-->
+            <!--        todo kijken of image in div kan playlist kan-->
 
-    </section>
+        </section>
 
-    <!--    todo dit lege blok nog stulen-->
-    <div class="stylingplaylist">
-        <picture>
-            <source srcset="assets/business.jpg?width=400&height=300&fit=cover&format=webp"
-                    type="image/webp">
+        <!--    todo dit lege blok nog stulen-->
+        <div class="stylingplaylist">
+            <picture>
+                <source srcset="assets/business.jpg?width=400&height=300&fit=cover&format=webp"
+                        type="image/webp">
 
-            <source srcset="assets/business.jpg?width=400&height=300&fit=cover&format=avif"
-                    type="image/avif">
+                <source srcset="assets/business.jpg?width=400&height=300&fit=cover&format=avif"
+                        type="image/avif">
 
-            <img src="assets/business.jpg?width=200&height=100&fit=cover" loading="lazy"
-                 alt="Image of the house" class="imageBNR lazyload">
-        </picture>
+                <img src="assets/business.jpg?width=200&height=100&fit=cover" loading="lazy"
+                     alt="Image of the house" class="imageBNR lazyload">
+            </picture>
 
-        <div class="playlist">
+            <div class="playlist">
 
-            <button class="playlist__icon" title="playlist icon" name="playlist icon">
+                <button class="playlist__icon" title="playlist icon" name="playlist icon">
 
-                <svg width="24" height="25" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M19 12.5c0 2.3-.8 4.5-2 6.2l.7.8c1.5-1.9 2.4-4.4 2.4-7 0-3.1-1.2-5.9-3.2-8l-.5 1c1.6 1.8 2.6 4.3 2.6 7z"
-                          fill="#000000"></path>
-                    <path d="M15.8 6.4l-.5 1c1.1 1.4 1.7 3.2 1.7 5.1 0 1.7-.5 3.2-1.3 4.6l.7.8c1.1-1.5 1.7-3.4 1.7-5.4-.1-2.3-.9-4.4-2.3-6.1z"
-                          fill="#000000"></path>
-                    <path d="M14.8 8.4l-.5 1.1c.5.9.8 1.9.8 3 0 1-.3 2-.7 2.9l.7.9c.6-1.1 1-2.4 1-3.7-.1-1.6-.5-3-1.3-4.2zM8.137 8.89a.5.5 0 01-.312.11H4.5a.5.5 0 00-.5.5v5a.5.5 0 00.5.5h3.325a.5.5 0 01.312.11l4.05 3.24a.5.5 0 00.813-.39V6.04a.5.5 0 00-.812-.39L8.137 8.89z"
-                          fill="#000000"></path>
-                </svg>
-            </button>
+                    <svg width="24" height="25" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M19 12.5c0 2.3-.8 4.5-2 6.2l.7.8c1.5-1.9 2.4-4.4 2.4-7 0-3.1-1.2-5.9-3.2-8l-.5 1c1.6 1.8 2.6 4.3 2.6 7z"
+                              fill="#000000"></path>
+                        <path d="M15.8 6.4l-.5 1c1.1 1.4 1.7 3.2 1.7 5.1 0 1.7-.5 3.2-1.3 4.6l.7.8c1.1-1.5 1.7-3.4 1.7-5.4-.1-2.3-.9-4.4-2.3-6.1z"
+                              fill="#000000"></path>
+                        <path d="M14.8 8.4l-.5 1.1c.5.9.8 1.9.8 3 0 1-.3 2-.7 2.9l.7.9c.6-1.1 1-2.4 1-3.7-.1-1.6-.5-3-1.3-4.2zM8.137 8.89a.5.5 0 01-.312.11H4.5a.5.5 0 00-.5.5v5a.5.5 0 00.5.5h3.325a.5.5 0 01.312.11l4.05 3.24a.5.5 0 00.813-.39V6.04a.5.5 0 00-.812-.39L8.137 8.89z"
+                              fill="#000000"></path>
+                    </svg>
+                </button>
 
                 <!--            <label>-->
                 <form class="playlist__div">
@@ -54,21 +60,23 @@
                     <label for="volume" class="playlist__inputRange"></label>
                 </form>
 
-            <!--            <span class="pleasurable"></span>-->
+                <!--            <span class="pleasurable"></span>-->
 
-            <!--   todo     arialabel hoeft niet gewoon tekst erin zetten-->
-            <button class="playbutton grow " name="playlistbutton" role="button" id="playbuttonstart"
-                    title="playlistbutton">
+                <!--   todo     arialabel hoeft niet gewoon tekst erin zetten-->
+                <button class="playbutton grow " name="playlistbutton" role="button" id="playbuttonstart"
+                        title="playlistbutton">
 
-                <!--     todo       kijken of pauzebutton op button zelf kan-->
-                <span class="pauzebutton ">
+                    <!--     todo       kijken of pauzebutton op button zelf kan-->
+                    <span class="pauzebutton ">
                 </span>
-            </button>
-            <audio controls class="audio" tabindex=" 0">
-                <source src="<%= audioUrl %>">
-            </audio>
+                </button>
+                <audio controls class="audio" tabindex=" 0">
+                    <source src="<%= audioUrl %>">
+                </audio>
 
+            </div>
         </div>
+
     </div>
 
     <a href="#top" class="backToTop ">
@@ -77,7 +85,7 @@
         </svg>
     </a>
     <!--    hier nth child gebruiken-->
-    <div class="divniews">
+    <div class="divnieuws">
         <section class="nieuws">
 
             <span class="nieuws__yellowBackground"></span>
@@ -86,7 +94,7 @@
 
             <ul class="nieuws__carousssel">
                 <!--                <li class="nieuws__filter">-->
-                <!--                    <button class="niews__button">-->
+                <!--                    <button class="nieuws__button">-->
                 <!--                        <svg xmlns="http://www.w3.org/2000/svg" width="17" height="13" fill="none">-->
                 <!--                            <path d="M6.5.5l-6 6 6 6 1.4-1.45L4.35 7.5H16.5v-2H4.35L7.9 1.95 6.5.5z" fill="#fff"></path>-->
                 <!--                        </svg>-->
@@ -103,7 +111,7 @@
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">Juridisch</a></li>
                 <!--                <li class="nieuws__filter">-->
 
-                <!--                    <button class="niews__button">-->
+                <!--                    <button class="nieuws__button">-->
                 <!--                        <svg xmlns="http://www.w3.org/2000/svg" width="17"-->
                 <!--                             height="13" fill="none">-->
                 <!--                            <path d="M10.5 12.5l6-6-6-6-1.4 1.45 3.55 3.55H.5v2h12.15L9.1 11.05l1.4 1.45z"-->

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,12 +9,11 @@
     <div class="playlist-intro">
         <section class="intro">
             <h1 id="top">BNR business beats </h1>
-            <p>Hier kunt u:</p>
-            <ul>
-                <li>luister naar muziek</li>
-                <li>     <a href="#nieuws">Nieuwsberichten lezen</a></li>
-            </ul>
-            <p>Hier kunt u naar muziek luisteeren met ieder half uur een niewsbulleting. Verder kunt u ook het laatste niews lezen</p>
+
+            <p>Hier kunt u naar muziek luisteeren met ieder half uur een niewsbulleting. Verder kunt u ook het laatste niews lezen
+            ga naar: <a href="#nieuws">Nieuws</a>
+
+            </p>
 
             <!--        https://developer.mozilla.org/en-US/docs/Web/CSS/animation-->
             <!--        todo kijken of image in div kan playlist kan-->

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,12 +7,16 @@
 
     <!--    hier nth child gebruiken-->
     <section class="intro">
-        <h1 id="top">BNR beats business</h1>
-        <p>Luister naar muziek en krijg ieder half uur een niewsbericht </p>
-        <p class="intoP">Ook kunt u de laatste niews artikelen lezen</p>
+        <h1 id="top">BNR business beats </h1>
+        <p>Luister naar muziek en krijg ieder half uur een niewsbericht  Ook kunt u de laatste niews artikelen lezen</p>
 
         <!--        https://developer.mozilla.org/en-US/docs/Web/CSS/animation-->
         <!--        todo kijken of image in div kan playlist kan-->
+
+    </section>
+
+    <!--    todo dit lege blok nog stulen-->
+    <div class="stylingplaylist">
         <picture>
             <source srcset="assets/business.jpg?width=400&height=300&fit=cover&format=webp"
                     type="image/webp">
@@ -23,50 +27,48 @@
             <img src="assets/business.jpg?width=200&height=100&fit=cover" loading="lazy"
                  alt="Image of the house" class="imageBNR lazyload">
         </picture>
-    </section>
 
-<!--    todo dit lege blok nog stulen-->
-    <div class="playlist" tabindex="0">
+        <div class="playlist">
 
-        <button class="playlist__icon">
+            <button class="playlist__icon" title="playlist icon" name="playlist icon">
 
-            <svg width="24" height="25" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M19 12.5c0 2.3-.8 4.5-2 6.2l.7.8c1.5-1.9 2.4-4.4 2.4-7 0-3.1-1.2-5.9-3.2-8l-.5 1c1.6 1.8 2.6 4.3 2.6 7z"
-                      fill="#FFD200"></path>
-                <path d="M15.8 6.4l-.5 1c1.1 1.4 1.7 3.2 1.7 5.1 0 1.7-.5 3.2-1.3 4.6l.7.8c1.1-1.5 1.7-3.4 1.7-5.4-.1-2.3-.9-4.4-2.3-6.1z"
-                      fill="#FFD200"></path>
-                <path d="M14.8 8.4l-.5 1.1c.5.9.8 1.9.8 3 0 1-.3 2-.7 2.9l.7.9c.6-1.1 1-2.4 1-3.7-.1-1.6-.5-3-1.3-4.2zM8.137 8.89a.5.5 0 01-.312.11H4.5a.5.5 0 00-.5.5v5a.5.5 0 00.5.5h3.325a.5.5 0 01.312.11l4.05 3.24a.5.5 0 00.813-.39V6.04a.5.5 0 00-.812-.39L8.137 8.89z"
-                      fill="#FFD200"></path>
-            </svg>
-        </button>
-        <div class="playlist__div" tabindex="0">
-<!--            <label>-->
-            <form>
+                <svg width="24" height="25" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M19 12.5c0 2.3-.8 4.5-2 6.2l.7.8c1.5-1.9 2.4-4.4 2.4-7 0-3.1-1.2-5.9-3.2-8l-.5 1c1.6 1.8 2.6 4.3 2.6 7z"
+                          fill="#000000"></path>
+                    <path d="M15.8 6.4l-.5 1c1.1 1.4 1.7 3.2 1.7 5.1 0 1.7-.5 3.2-1.3 4.6l.7.8c1.1-1.5 1.7-3.4 1.7-5.4-.1-2.3-.9-4.4-2.3-6.1z"
+                          fill="#000000"></path>
+                    <path d="M14.8 8.4l-.5 1.1c.5.9.8 1.9.8 3 0 1-.3 2-.7 2.9l.7.9c.6-1.1 1-2.4 1-3.7-.1-1.6-.5-3-1.3-4.2zM8.137 8.89a.5.5 0 01-.312.11H4.5a.5.5 0 00-.5.5v5a.5.5 0 00.5.5h3.325a.5.5 0 01.312.11l4.05 3.24a.5.5 0 00.813-.39V6.04a.5.5 0 00-.812-.39L8.137 8.89z"
+                          fill="#000000"></path>
+                </svg>
+            </button>
+
+                <!--            <label>-->
+                <form class="playlist__div">
 
 
-            <label>
-<!--               todo  hier nog een form omheen zetten vanwege toegankelijkheid-->
-                <input type="range" class="playlist__inputRange" name="volume" min="0" max="10"/>
-            </label>
-            <!--            </label>-->
-            <label for="volume" class="playlist__inputRange"></label>
-            </form>
-        </div>
+                    <label>
+                        <!--               todo  hier nog een form omheen zetten vanwege toegankelijkheid-->
+                        <input type="range" class="playlist__inputRange" name="volume" min="0" max="10"/>
+                    </label>
+                    <!--            </label>-->
+                    <label for="volume" class="playlist__inputRange"></label>
+                </form>
 
-        <!--            <span class="pleasurable"></span>-->
+            <!--            <span class="pleasurable"></span>-->
 
-<!--   todo     arialabel hoeft niet gewoon tekst erin zetten-->
-        <button class="playbutton grow " name="playlistbutton" role="button" id="playbuttonstart"
-                aria-label="this is the button to start teh playlist">
+            <!--   todo     arialabel hoeft niet gewoon tekst erin zetten-->
+            <button class="playbutton grow " name="playlistbutton" role="button" id="playbuttonstart"
+                    title="playlistbutton">
 
-<!--     todo       kijken of pauzebutton op button zelf kan-->
-            <span class="pauzebutton " tabindex="0">
+                <!--     todo       kijken of pauzebutton op button zelf kan-->
+                <span class="pauzebutton ">
                 </span>
-        </button>
-        <audio controls class="audio" tabindex=" 0">
-            <source src="<%= audioUrl %>">
-        </audio>
+            </button>
+            <audio controls class="audio" tabindex=" 0">
+                <source src="<%= audioUrl %>">
+            </audio>
 
+        </div>
     </div>
 
     <a href="#top" class="backToTop ">
@@ -83,13 +85,13 @@
             <h1 class="nieuws__h1">Nieuws</h1>
 
             <ul class="nieuws__carousssel">
-                <li class="nieuws__filter">
-                    <button class="niews__button">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="17" height="13" fill="none">
-                            <path d="M6.5.5l-6 6 6 6 1.4-1.45L4.35 7.5H16.5v-2H4.35L7.9 1.95 6.5.5z" fill="#fff"></path>
-                        </svg>
-                    </button>
-                </li>
+                <!--                <li class="nieuws__filter">-->
+                <!--                    <button class="niews__button">-->
+                <!--                        <svg xmlns="http://www.w3.org/2000/svg" width="17" height="13" fill="none">-->
+                <!--                            <path d="M6.5.5l-6 6 6 6 1.4-1.45L4.35 7.5H16.5v-2H4.35L7.9 1.95 6.5.5z" fill="#fff"></path>-->
+                <!--                        </svg>-->
+                <!--                    </button>-->
+                <!--                </li>-->
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">alles</a></li>
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">economie</a></li>
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">ondernemen&werk</a></li>
@@ -99,46 +101,53 @@
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">Duurzaamheid</a></li>
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">Marketing&media</a></li>
                 <li class="nieuws__filter"><a href="#nieuws" class="nieuws__link">Juridisch</a></li>
-                <li class="nieuws__filter">
+                <!--                <li class="nieuws__filter">-->
 
-                    <button class="niews__button">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="17"
-                             height="13" fill="none">
-                            <path d="M10.5 12.5l6-6-6-6-1.4 1.45 3.55 3.55H.5v2h12.15L9.1 11.05l1.4 1.45z"
-                                  fill="#fff"></path>
-                        </svg>
-                    </button>
-                </li>
+                <!--                    <button class="niews__button">-->
+                <!--                        <svg xmlns="http://www.w3.org/2000/svg" width="17"-->
+                <!--                             height="13" fill="none">-->
+                <!--                            <path d="M10.5 12.5l6-6-6-6-1.4 1.45 3.55 3.55H.5v2h12.15L9.1 11.05l1.4 1.45z"-->
+                <!--                                  fill="#fff"></path>-->
+                <!--                        </svg>-->
+                <!--                    </button>-->
+                <!--                </li>-->
             </ul>
 
         </section>
 
-        <h1 id="nieuws">zie alle niewsartikelen</h1>
 
-        <section class="sectionArticles">
+        <section class="">
+            <h1 id="nieuws">zie alle nieuwsartikelen</h1>
+            <div class="sectionArticles">
 
-            <% firstTenArticles.forEach(article => { %>
-                <article class="articles">
-                    <h2 class="article__title"><%= article.title %></h2>
-                    <p class="article__text"><%= article.introduction %></p>
-                    <% if (article.photo) { %>
-                        <picture>
-                            <source srcset="<%= article.photo.URL %>?width=400&height=300&fit=cover&format=avif"
-                                    type="image/avif">
+                <% firstTenArticles.forEach(article => { %>
+                    <article class="articles">
+                        <h2 class="article__title"><%= article.title %></h2>
+                        <p class="article__text"><%= article.introduction %></p>
+                        <% if (article.photo) { %>
+                            <picture>
+                                <source srcset="<%= article.photo.URL %>?width=400&height=300&fit=cover&format=avif"
+                                        type="image/avif">
 
-                            <source srcset="<%= article.photo.URL %>?width=400&height=300&fit=cover&format=webp"
-                                    type="image/webp">
+                                <source srcset="<%= article.photo.URL %>?width=400&height=300&fit=cover&format=webp"
+                                        type="image/webp">
 
 
-                            <img src="<%= article.photo.URL %>?width=200&height=100&fit=cover" loading="lazy"
-                                 alt="Image of the house"
-                                 width="<%= article.photo.URL %>"
-                                 height=" <%= article.photo.URL %>" class="article__img">
-                        </picture>
-                    <% } %>
-                </article>
-            <% }) %>
-
+                                <img src="<%= article.photo.URL %>?width=200&height=100&fit=cover" loading="lazy"
+                                     alt="Image of the house"
+                                     width="<%= article.photo.URL %>"
+                                     height=" <%= article.photo.URL %>" class="article__img">
+                            </picture>
+                        <% } %>
+                    </article>
+                <% }) %>
+            </div>
+            <div class="stylingButton">
+                <a
+                    class="bekijkmeerButton"
+                    href="">Alles bekijken
+                </a>
+            </div>
         </section>
     </div>
 


### PR DESCRIPTION
<img width="728" alt="image" src="https://github.com/yujing-student/proof-of-concept/assets/100352887/dbe8c8c2-d73e-4a8a-96d4-5b42974272da">

de tekst en de playlist staat nu naast elkaar op desktop en tablet
<br>
de navigatie is iets anders waardoor het al meer van bnr is en er minder gap is tussen de filters

<img width="928" alt="image" src="https://github.com/yujing-student/proof-of-concept/assets/100352887/b407feb5-ebbf-49e7-8c98-f710e1292796">

<br>

ook is deze knop toegevoegd 

<img width="646" alt="image" src="https://github.com/yujing-student/proof-of-concept/assets/100352887/4fdad6d8-066d-495e-9a8d-ca43232401ea">

